### PR TITLE
fix the slider not showing problem by removing class collision

### DIFF
--- a/src/partials/reviews.html
+++ b/src/partials/reviews.html
@@ -5,7 +5,7 @@
   </h2>
   <div class="card-container">
     <!-- First Set -->
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/Profile1.png" alt="Profile 1" />
       </div>
@@ -15,7 +15,7 @@
         party. They carved beautifully and lasted for weeks!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile2.png" alt="Profile 2" />
       </div>
@@ -25,7 +25,7 @@
         with the Sugar Pie variety, and the flavor was incredible!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile3.png" alt="Profile 3" />
       </div>
@@ -37,7 +37,7 @@
     </div>
 
     <!-- Second Set -->
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/Profile1.png" alt="Profile 1" />
       </div>
@@ -47,7 +47,7 @@
         party. They carved beautifully and lasted for weeks!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile2.png" alt="Profile 2" />
       </div>
@@ -57,7 +57,7 @@
         with the Sugar Pie variety, and the flavor was incredible!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile3.png" alt="Profile 3" />
       </div>
@@ -69,7 +69,7 @@
     </div>
 
     <!-- Third Set -->
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/Profile1.png" alt="Profile 1" />
       </div>
@@ -79,7 +79,7 @@
         party. They carved beautifully and lasted for weeks!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile2.png" alt="Profile 2" />
       </div>
@@ -89,7 +89,7 @@
         with the Sugar Pie variety, and the flavor was incredible!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile3.png" alt="Profile 3" />
       </div>
@@ -101,7 +101,7 @@
     </div>
 
     <!-- Fourth Set -->
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/Profile1.png" alt="Profile 1" />
       </div>
@@ -111,7 +111,7 @@
         party. They carved beautifully and lasted for weeks!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile2.png" alt="Profile 2" />
       </div>
@@ -121,7 +121,7 @@
         with the Sugar Pie variety, and the flavor was incredible!
       </p>
     </div>
-    <div class="card">
+    <div class="review-card">
       <div class="profile-circle">
         <img src="/images/profile3.png" alt="Profile 3" />
       </div>

--- a/src/styles/reviews.css
+++ b/src/styles/reviews.css
@@ -51,7 +51,7 @@
     padding-top: 70px;
 }
 
-.card {
+.review-card {
     flex: 1 0 calc(8.33% - 20px);
     margin: 30px 10px;
     padding: 20px;
@@ -63,7 +63,7 @@
     min-width: 300px;
 }
 
-.card h3 {
+.review-card h3 {
     font-family: var(--secondary-text-font);
     font-size: 18px;
     font-weight: 600;
@@ -72,7 +72,7 @@
     margin-top: 20px;
 }
 
-.card p {
+.review-card p {
     font-family: var(--secondary-text-font);
     font-size: 14px;
     font-weight: 400;


### PR DESCRIPTION
**PR Description:**

Fixed the issue where the slider was not showing on the screen by removing a class collision. Updated class names in `review.html` and the corresponding CSS file to ensure proper display. Previously, the slider had a default `display: none` property, possibly due to a class name conflict with another component. The changes ensure the slider is now visible as intended.